### PR TITLE
Link mapnodes to backend

### DIFF
--- a/src/components/MapMenuView.tsx
+++ b/src/components/MapMenuView.tsx
@@ -173,7 +173,12 @@ const MapMenu = ({
 				<MapMenuHeader
 					info={info[id]}
 					height={collapsedHeight}
-					onButton={setMapProperty}
+					onButton={
+						setMapProperty &&
+						(() => {
+							setMapProperty(id);
+						})
+					}
 					standalone={false}
 					{...panResponder.panHandlers}
 				/>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,4 @@
+const baseUrl =
+	'http://bruinbot-load-balancer-1177858409.us-west-1.elb.amazonaws.com/';
+
+export { baseUrl };

--- a/src/containers/MapScreen.tsx
+++ b/src/containers/MapScreen.tsx
@@ -222,6 +222,7 @@ const formatMapNodesData = (apiData: MapNode[]) => {
 	const mapNodeHeaderInfo: MapMenuProps['info'] = {};
 	console.log(apiData);
 	apiData.forEach((node, idx) => {
+		// TODO: figure out what to name intermediate checkpoints
 		let name = node.name
 			? node.name
 			: 'Checkpoint ' +
@@ -235,7 +236,7 @@ const formatMapNodesData = (apiData: MapNode[]) => {
 		mapNodeHeaderInfo[node._id] = {
 			topLeft: name,
 			topRight: node.distance.toFixed(0).toString() + 'm away',
-			bottomRight: node.eta.toFixed(1).toString() + ' minute(s)',
+			bottomRight: node.eta.toFixed(1).toString() + ' minutes',
 			imgSrc: [LocationImgA, LocationImgB, LocationImgC][idx % 3],
 		};
 	});

--- a/src/containers/auth/SignupScreen.tsx
+++ b/src/containers/auth/SignupScreen.tsx
@@ -1,16 +1,16 @@
-import { StackNavigationProp } from '@react-navigation/stack';
-import { FirebaseError } from 'firebase';
 import React, { useContext, useState } from 'react';
 import { Button, Input } from 'react-native-elements';
+
+import { StackNavigationProp } from '@react-navigation/stack';
+import { FirebaseError } from 'firebase';
+import Axios from 'axios';
+
+import { baseUrl } from '../../config';
 import { RootStackParamList } from '../../../App';
 import { Ctx } from '../../components/StateProvider';
 import Form from './Form';
 import { styles } from './FormStyles';
 import { handleAuthErrors, PasswordInput } from './FormUtils';
-import Axios from 'axios';
-
-const baseUrl =
-	'http://bruinbot-load-balancer-1177858409.us-west-1.elb.amazonaws.com';
 
 type Props = {
 	navigation: StackNavigationProp<RootStackParamList, 'Signup'>;

--- a/src/services/BotService.ts
+++ b/src/services/BotService.ts
@@ -1,10 +1,10 @@
 import Axios from 'axios';
 
+import { baseUrl } from '../config';
 import { EventBot, Bot } from '../types/apiTypes';
 
 const axios = Axios.create({
-	baseURL:
-		'http://bruinbot-load-balancer-1177858409.us-west-1.elb.amazonaws.com/',
+	baseURL: baseUrl,
 	withCredentials: true,
 });
 

--- a/src/services/MapService.ts
+++ b/src/services/MapService.ts
@@ -1,48 +1,28 @@
 import Axios from 'axios';
 
+import { baseUrl } from '../config';
 import { MapNode } from '../types/apiTypes';
 
-// TODO: remove later
-async function getMapNodesSample() {
-	const data: MapNode[] = [
-		{
-			_id: '5fc86e16b9d0df06d8a3b95c',
-			location: {
-				_id: '5fc86e16b9d0df06d8a3b95b',
-				latitude: 34.0714,
-				longitude: -118.4439,
-			},
-			name: 'Powell Library',
-			distance: 1.0,
-			eta: 90,
-			__v: 0,
-		},
-		{
-			_id: '5fc86e16b9d0df06d8a3b959',
-			location: {
-				_id: '5fc86e16b9d0df06d8a3b958',
-				latitude: 34.0735,
-				longitude: -118.4432,
-			},
-			name: 'Sculpture Garden',
-			distance: 5.0,
-			eta: 60,
-			__v: 0,
-		},
-		{
-			_id: '5fc86e21b9d0df06d8a3b962',
-			location: {
-				_id: '5fc86e21b9d0df06d8a3b961',
-				latitude: 34.067,
-				longitude: -118.443,
-			},
-			name: 'Boelter Hall',
-			distance: 15.0,
-			eta: 80,
-			__v: 0,
-		},
-	];
-	return Promise.resolve(data);
+const axios = Axios.create({
+	baseURL: baseUrl,
+	withCredentials: true,
+});
+
+async function getMapNodes(latitude: number, longitude: number) {
+	try {
+		const data: MapNode[] = (
+			await axios.get('/paths/nodes/location', {
+				params: {
+					latitude: latitude,
+					longitude: longitude,
+				},
+			})
+		).data;
+		return data;
+	} catch (e) {
+		console.log(e);
+		throw e;
+	}
 }
 
-export default { getMapNodesSample };
+export default { getMapNodes };

--- a/src/types/inventoryTypes.ts
+++ b/src/types/inventoryTypes.ts
@@ -32,9 +32,9 @@ export interface HeaderProps {
 	/**
 	 * Callback for the button on the header. Could be used for anything
 	 *
-	 * @param bool Boolean for whether to show
+	 * @param val Boolean for whether to show
 	 */
-	onButton?(bool: boolean): any;
+	onButton?(val: any): any;
 }
 
 export interface MapMenuProps {
@@ -45,8 +45,7 @@ export interface MapMenuProps {
 	collapsable?: boolean;
 
 	/**
-	 * Function to change some map property, e.g. setVar of useState(), currently
-	 * used to pass along MapScreen's setShowMap() hook to MapMenuHeader's onButton()
+	 * Function to change some map property, e.g. setVar of useState()
 	 *
 	 * @param val Value to be passed into the function
 	 */

--- a/src/types/mapTypes.ts
+++ b/src/types/mapTypes.ts
@@ -26,6 +26,8 @@ export interface PropTypes {
 	 * Function for when a bot is selected
 	 *
 	 * @param id Id of bot
+	 * @param lat Latitude of bot
+	 * @param lon Longitude of bot
 	 */
-	onSelect(id: string): any;
+	onSelect(id: string, lat?: number, lon?: number): any;
 }


### PR DESCRIPTION
## Description
- Tapping the order button fires a request to get all map nodes with distance and eta based on the selected bot's location
- Refresh button updated to also fire this request in map node mode
- Renamed some variables for clarity
- Put baseURL into `/src/config.js`

## Screenshot
![IMG_7062](https://user-images.githubusercontent.com/32371937/102309012-b4ce8680-3f1c-11eb-8477-37dcfe5afa75.PNG)

## Notion
https://www.notion.so/uclabruinbot/Link-map-node-mode-to-the-backend-1d42ffca5a8347f6b6fedba1a7dd38f2
