### PR TITLE
Show Bruinbot and its straightline path between mapnodes

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -14,10 +14,12 @@ import { MAP_MARKER_SIZE } from '../constants';
 import mapDest from '../assets/mapDest.png';
 import mapPinPrimary from '../assets/mapPin1.gif';
 import mapPinSecondary from '../assets/mapPin3.gif';
+import mapPinTertiary from '../assets/mapPin2.gif';
 
 const MapComponent = ({
 	initRegion,
 	markers,
+	centralMarker,
 	polygonCoords,
 	lineCoords,
 	refresh,
@@ -93,6 +95,15 @@ const MapComponent = ({
 							</Marker>
 						);
 					})}
+				{selected && centralMarker && (
+					<Polyline
+						coordinates={[selected.location, centralMarker.location]}
+						strokeColor="white"
+						strokeWidth={4}
+						lineJoin="bevel"
+						lineDashPattern={[10]}
+					/>
+				)}
 				{markers.map((marker) => (
 					<Marker
 						tracksViewChanges={false}
@@ -103,9 +114,9 @@ const MapComponent = ({
 						}}
 						centerOffset={{ x: 0, y: -MAP_MARKER_SIZE / 2 + 5 }}
 						title={marker.name}
-						onPress={() => onSelect(marker._id)}
+						onPress={() => onSelect(marker)}
 					>
-						{marker._id === selected ? (
+						{selected && marker._id === selected._id ? (
 							<Image
 								source={mapPinSecondary}
 								style={styles.pin}
@@ -120,6 +131,20 @@ const MapComponent = ({
 						)}
 					</Marker>
 				))}
+				{centralMarker && (
+					<Marker
+						tracksViewChanges={false}
+						coordinate={centralMarker.location}
+						centerOffset={{ x: 0, y: -MAP_MARKER_SIZE / 2 + 5 }}
+						title={centralMarker.name}
+					>
+						<Image
+							source={mapPinTertiary}
+							style={styles.pin}
+							resizeMode="contain"
+						/>
+					</Marker>
+				)}
 			</MapView>
 			<TouchableOpacity
 				style={{ ...styles.button, marginBottom: 60 }}

--- a/src/containers/MapScreen.tsx
+++ b/src/containers/MapScreen.tsx
@@ -24,8 +24,6 @@ import Loading from '../components/Loading';
 const MILLISECONDS_IN_SECOND = 1000;
 
 const MapScreen = () => {
-	// const [centralMarker, setCentralMarker] = useState<MarkerData | null>(null);
-
 	// For displaying the markers on the map
 	const [markers, setMarkers] = useState<{ [key: string]: MarkerData } | null>(
 		null
@@ -44,7 +42,7 @@ const MapScreen = () => {
 	} | null>(null);
 
 	// Id of the marker that is currently selected
-	const [selectedMarker, setSelected] = useState('');
+	const [selectedMarker, setSelected] = useState<MarkerData | null>(null);
 
 	// true -> map nodes displayed on map, false -> bots displayed on map
 	const [showMapNodes, setShowMapNodes] = useState(false);
@@ -127,6 +125,7 @@ const MapScreen = () => {
 					<MapComponent
 						initRegion={CampusData.region}
 						markers={Object.values(markers)}
+						centralMarker={selectedBotForOrder}
 						markerImg={Marker}
 						polygonCoords={CampusData.polygon.map(([lat, lng]) => ({
 							latitude: lat,
@@ -138,14 +137,14 @@ const MapScreen = () => {
 								selectedBotForOrder.location.longitude
 							);
 						}}
-						selected={selectedMarker}
-						onSelect={(id: string) => {
-							setSelected(id);
+						selected={selectedMarker ? selectedMarker : undefined}
+						onSelect={(marker: MarkerData) => {
+							setSelected(marker);
 						}}
 					/>
 				</View>
 				<MapMenuHeader
-					info={headerInfo[selectedMarker]}
+					info={headerInfo[selectedMarker ? selectedMarker._id : '']}
 					standalone={true}
 					onButton={() => {
 						// for now, go back to map with btos
@@ -176,12 +175,12 @@ const MapScreen = () => {
 						}))}
 						lineCoords={botPaths ? Object.values(botPaths) : []}
 						refresh={runRequests}
-						selected={selectedMarker}
-						onSelect={(id: string) => setSelected(id)}
+						selected={selectedMarker ? selectedMarker : undefined}
+						onSelect={(marker: MarkerData) => setSelected(marker)}
 					/>
 				</View>
 				<MapMenu
-					id={selectedMarker}
+					id={selectedMarker ? selectedMarker._id : ''}
 					info={headerInfo}
 					items={inventories}
 					setMapProperty={(id: string) => {
@@ -278,7 +277,6 @@ const formatEventBotsData = (apiData: EventBot[]) => {
 const formatMapNodesData = (apiData: MapNode[]) => {
 	const mapNodeMarkers: { [key: string]: MarkerData } = {};
 	const mapNodeHeaderInfo: MapMenuProps['info'] = {};
-	console.log(apiData);
 	apiData.forEach((node, idx) => {
 		// TODO: figure out what to name intermediate checkpoints
 		let name = node.name

--- a/src/types/mapTypes.ts
+++ b/src/types/mapTypes.ts
@@ -20,14 +20,14 @@ export interface PropTypes {
 	lineCoords?: LatLng[][];
 	mapNodes?: MarkerData[];
 	refresh(): any;
-	selected: string;
+	selected?: MarkerData;
 
 	/**
-	 * Function for when a bot is selected
+	 * Function for when a marker is selected
 	 *
 	 * @param id Id of bot
 	 * @param lat Latitude of bot
 	 * @param lon Longitude of bot
 	 */
-	onSelect(id: string, lat?: number, lon?: number): any;
+	onSelect(marker: MarkerData): any;
 }


### PR DESCRIPTION
## Description
- Changed selected from String (representing id) to MarkerData (representing the actual object)
  - The actual selected object's location is needed to form the line between the bot and map node
- Passes in centralMarker to draw the bot location in the map node view

## Screenshot
![IMG_7119](https://user-images.githubusercontent.com/32371937/102688959-6c7ac700-41af-11eb-8225-af8399d445ee.PNG)

## Notion
https://www.notion.so/uclabruinbot/Show-user-selected-bot-on-the-map-543ac5bd54364b6db15516a58b876f52