### PR TITLE
Fix warning upon load of new map nodes

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -205,30 +205,33 @@ const MapComponent = ({
 						lineDashPattern={[10]}
 					/>
 				)}
-				{markers.map((marker) => (
-					<MarkerAnimated
-						tracksViewChanges={false}
-						key={marker._id}
-						coordinate={animatedLocations[marker._id]}
-						centerOffset={{ x: 0, y: -MAP_MARKER_SIZE / 2 + 5 }}
-						title={marker.name}
-						onPress={() => onSelect(marker)}
-					>
-						{selected && marker._id === selected._id ? (
-							<Image
-								source={mapPinSecondary}
-								style={styles.pin}
-								resizeMode="contain"
-							/>
-						) : (
-							<Image
-								source={mapPinPrimary}
-								style={styles.pin}
-								resizeMode="contain"
-							/>
-						)}
-					</MarkerAnimated>
-				))}
+				{markers.map(
+					(marker) =>
+						animatedLocations[marker._id] && (
+							<MarkerAnimated
+								tracksViewChanges={false}
+								key={marker._id}
+								coordinate={animatedLocations[marker._id]}
+								centerOffset={{ x: 0, y: -MAP_MARKER_SIZE / 2 + 5 }}
+								title={marker.name}
+								onPress={() => onSelect(marker)}
+							>
+								{selected && marker._id === selected._id ? (
+									<Image
+										source={mapPinSecondary}
+										style={styles.pin}
+										resizeMode="contain"
+									/>
+								) : (
+									<Image
+										source={mapPinPrimary}
+										style={styles.pin}
+										resizeMode="contain"
+									/>
+								)}
+							</MarkerAnimated>
+						)
+				)}
 				{centralMarker && (
 					<Marker
 						tracksViewChanges={false}


### PR DESCRIPTION
Warning upon the load of a new collection of map nodes originated from the attempt to render markers during the transition from the old collection markers to the new collection markers. During that transition, the collection remains empty for a short period of time. The fix adds a check to ensure that, for a given marker ID, there is valid data to be 
rendered into a marker for the map.

Upon the load of the map following a user tapping the "Order" button, there is no more warning at the bottom of the below screen as there previously was.

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-01-13 at 20 30 01](https://user-images.githubusercontent.com/53080395/104545088-1e09ee00-55de-11eb-9672-3bdcae2f2eb7.png)