### PR TITLE
Max/destroy screen when navigating

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -74,7 +74,11 @@ const Home = () => {
 				<Stack.Screen name="Signup" component={SignupScreen} />
 				<Stack.Screen name="PasswordReset" component={PasswordResetScreen} />
 				<Stack.Screen name="Dashboard" component={DashboardScreen} />
-				<Stack.Screen name="Map" component={MapScreen} />
+				<Stack.Screen
+					name="Map"
+					component={MapScreen}
+					options={{ unmountOnBlur: true }}
+				/>
 				<Stack.Screen name="ItemCatalogue" component={ItemCatalogue} />
 				<Stack.Screen name="PaymentInfo" component={PaymentInfo} />
 				<Stack.Screen name="PaymentSuccess" component={PaymentSuccess} />
@@ -85,7 +89,11 @@ const Home = () => {
 		// TODO: Change this to be something the user can toggle
 		stack = state.user.eventId ? (
 			<>
-				<Stack.Screen name="Map" component={MapScreen} />
+				<Stack.Screen
+					name="Map"
+					component={MapScreen}
+					options={{ unmountOnBlur: true }}
+				/>
 				<Stack.Screen name="ItemCatalogue" component={ItemCatalogue} />
 				<Stack.Screen name="Qr" component={QrScreen} />
 				<Stack.Screen name="AddItem" component={AddItem} />

--- a/src/containers/MapScreen.tsx
+++ b/src/containers/MapScreen.tsx
@@ -51,11 +51,6 @@ const MapScreen = () => {
 		setSelectedBotForOrder,
 	] = useState<MarkerData | null>(null);
 
-	// Holds the timeout object that runs requests periodically
-	const [updateInterval, setUpdateInterval] = useState<ReturnType<
-		typeof setTimeout
-	> | null>(null);
-
 	const [loading, setLoading] = useState<boolean>(false);
 	const { state } = useContext(Ctx);
 
@@ -101,13 +96,16 @@ const MapScreen = () => {
 	}
 
 	useEffect(() => {
+		let intervalId: ReturnType<typeof setTimeout> | null = null;
 		if (!showMapNodes) {
 			runRequests();
-			setUpdateInterval(setInterval(runRequests, MAP_REFRESH_RATE));
+			intervalId = setInterval(runRequests, MAP_REFRESH_RATE);
 		} else {
-			clearInterval(updateInterval!!);
+			clearInterval(intervalId!!);
 		}
-		return () => clearInterval(updateInterval!!);
+		return () => {
+			clearInterval(intervalId!!);
+		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [showMapNodes]);
 


### PR DESCRIPTION
tldr: this commit should have fixed all of my bug tickets
Changes:
1. Map screen will be unmounted when we navigate away from it.
2. Map screen won't make a request every 10 seconds after it is unmounted.
3. Camera should be off now after navigating away from QR screen.
4. Scanning an erroneous QR code won't result in multiple error alert boxes. (Pressing the OK on the error alert box will re-enable the scanner, so if you always have the erroneous QR code in your camera's view, you will keep getting the alert boxes one after another)
Note: QR screen is not and should not be unmounted after navigating away, because it calls to handle initial URL from deep link each time a QR screen is created. I've used some locks to lock the camera away when we navigate away from QR screen.