### PR TITLE
Update context for Enterprise mode toggle

### DIFF
--- a/src/components/StateProvider.tsx
+++ b/src/components/StateProvider.tsx
@@ -1,5 +1,6 @@
 import {
 	Action,
+	SetEnterpriseAction,
 	SetUserAction,
 	State,
 	StateAndDispatch,
@@ -18,7 +19,7 @@ const firebaseConfig = {
 };
 firebase.initializeApp(firebaseConfig);
 
-const initialState: State = { firebase, user: null };
+const initialState: State = { firebase, user: null, isEnterpriseMode: false };
 const Ctx = React.createContext<StateAndDispatch>(undefined!);
 
 const StateProvider = (props: { children: React.ReactNode }) => {
@@ -29,6 +30,11 @@ const StateProvider = (props: { children: React.ReactNode }) => {
 				return {
 					...state,
 					user: (action as SetUserAction).user,
+				};
+			} else if (action.type === 'SET_ENTERPRISE_MODE') {
+				return {
+					...state,
+					isEnterpriseMode: (action as SetEnterpriseAction).isEnterpriseMode,
 				};
 			}
 			return state;

--- a/src/containers/DrawerScreen.tsx
+++ b/src/containers/DrawerScreen.tsx
@@ -1,17 +1,20 @@
-import { DrawerNavigationProp } from '@react-navigation/drawer';
-import React, { useState } from 'react';
-
 import { Alert } from 'react-native';
+import { Ctx } from '../components/StateProvider';
+import { DrawerNavigationProp } from '@react-navigation/drawer';
 import { RootStackParamList } from '../../App';
 import DrawerMenu, { Link } from '../components/DrawerView';
 import Ham from '../assets/greenHam.jpg';
+import React, { useContext } from 'react';
 
 interface Props {
 	navigation: DrawerNavigationProp<RootStackParamList>;
 }
 
 const Drawer = ({ navigation }: Props) => {
-	const [enterpriseMode, setEnterpriseMode] = useState(true);
+	const {
+		state: { isEnterpriseMode },
+		dispatch,
+	} = useContext(Ctx);
 
 	const userHeader = {
 		// TODO: get text programatically
@@ -81,14 +84,12 @@ const Drawer = ({ navigation }: Props) => {
 		},
 	];
 
-	// TODO: This should check whether the user has organizer privileges and also should set some
-	// context field so that the rest of our app knows which mode our user is in.
-
 	const menuProps = {
-		headerProps: enterpriseMode ? enterpriseHeader : userHeader,
-		links: enterpriseMode ? enterpriseLinks : userLinks,
-		toggleState: enterpriseMode,
-		onToggleChange: (val: boolean) => setEnterpriseMode(val),
+		headerProps: isEnterpriseMode ? enterpriseHeader : userHeader,
+		links: isEnterpriseMode ? enterpriseLinks : userLinks,
+		toggleState: isEnterpriseMode,
+		onToggleChange: (mode: boolean) =>
+			dispatch({ type: 'SET_ENTERPRISE_MODE', isEnterpriseMode: mode }),
 	};
 
 	return <DrawerMenu {...menuProps} />;

--- a/src/types/StateProviderTypes.tsx
+++ b/src/types/StateProviderTypes.tsx
@@ -7,16 +7,22 @@ interface SetUserAction {
 	user: (FirebaseUser & UserData) | null;
 }
 
+interface SetEnterpriseAction {
+	type: string;
+	isEnterpriseMode: boolean;
+}
+
 // TODO: Put these types into another file
 interface FirebaseUser {
 	uid: string;
 }
 
-type Action = SetUserAction;
+type Action = SetUserAction | SetEnterpriseAction;
 
 interface State {
 	firebase: typeof firebase;
 	user: (FirebaseUser & UserData) | null;
+	isEnterpriseMode: boolean;
 }
 
 interface StateAndDispatch {
@@ -24,4 +30,4 @@ interface StateAndDispatch {
 	dispatch: Dispatch<Action>;
 }
 
-export { State, StateAndDispatch, Action, SetUserAction };
+export { State, StateAndDispatch, Action, SetUserAction, SetEnterpriseAction };


### PR DESCRIPTION
## Changes
- no visual changes
- added new state and action
  - `isEnterpriseMode` boolean for whether user is in enterprise mode
  - `SET_ENTERPRISE_MODE` action for setting `isEnterpriseMode`
- linked up toggle button in the drawer to React context
- TODO: Coordinate with @Zhirschhorn so that his new dynamic dashboard screen uses this context state