### PR TITLE
Fix item widths in inventory display

### DIFF
--- a/src/components/MapMenuView.tsx
+++ b/src/components/MapMenuView.tsx
@@ -25,7 +25,9 @@ import { NAV_HEIGHT } from '../constants';
 const HEADER_HEIGHT = 150;
 const BUFFER_HEIGHT = 30;
 
-const inventoryHeight = Dimensions.get('window').height - (NAV_HEIGHT + 10);
+const screenWidth = Dimensions.get('window').width;
+const screenHeight = Dimensions.get('window').height;
+const inventoryHeight = screenHeight - (NAV_HEIGHT + 10);
 
 const Item = ({
 	_id,
@@ -38,7 +40,14 @@ const Item = ({
 	bot,
 }: InventoryItemProps) => {
 	const itemBody = (
-		<View style={styles.item} key={_id}>
+		<View
+			style={{
+				...styles.item,
+				// adjust item width when nested under TouchableOpacity
+				width: clickable ? screenWidth * 0.44 : styles.item.width,
+			}}
+			key={_id}
+		>
 			<Image
 				style={{
 					width: '100%',
@@ -238,8 +247,6 @@ const MapMenu = ({
 		return <View />;
 	}
 
-	console.log(items);
-
 	if (!items) {
 		return <MapMenuHeader info={info[id]} standalone={true} />;
 	} else {
@@ -284,9 +291,6 @@ const MapMenu = ({
 		);
 	}
 };
-
-const screenWidth = Dimensions.get('window').width;
-const screenHeight = Dimensions.get('window').height;
 
 const styles = StyleSheet.create({
 	header: {


### PR DESCRIPTION
<p align="center">
<img width="350" src="https://user-images.githubusercontent.com/44995807/106534453-f1444a80-64a8-11eb-86a2-6d1ce9ff03e0.png">
</p>

## Changes
- quick fix, adjusted the item widths in the inventory when they are wrapped in a `TouchableOpacity`
  - in reference to this [Kanban issue](https://www.notion.so/Bug-MapMenuView-Not-Displaying-Properly-582f1d7bead2461cba0688bfd866e6f8)