### PR TITLE
Switch provider to google maps

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -146,6 +146,7 @@ const MapComponent = ({
 	return (
 		<>
 			<MapView
+				provider="google"
 				initialCamera={initCameraView}
 				onRegionChangeComplete={(coord) => {
 					if (!coordInRegion(coord, initRegion)) {


### PR DESCRIPTION
<p align="center">
  <img width="350" src="https://user-images.githubusercontent.com/44995807/107130790-ecefa700-6885-11eb-8960-55c02062335d.gif"/>
</p>

## Changes

- quick fix to switch back to Google maps instead of Apple
  - and in the end, we just came crawling back...
- addresses bug with [swiping](https://www.notion.so/Bug-User-s-swipe-continues-after-re-centering-map-2cef373fedbf40ac915a4e6411d9f9d9) and with markers [bugging out](https://www.notion.so/Bug-Map-mode-selection-marker-tradeof-1bc57e502eb14230a999109492dacc3c)
- reintroduces an old bug with buggy background color of the map polygon over UCLA :)
- shouldn't break anything on Android