### PR TITLE
Fix some back buttons

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -38,7 +38,7 @@ export type RootStackParamList = {
 	Signup: undefined;
 	PasswordReset: undefined;
 	Blank: undefined;
-	Map: undefined;
+	BottomBar: undefined;
 	SelectMarker: { markers: MarkerData[]; selectedId: Bot['_id'] | null };
 	InventoryModification: { bot: Bot };
 	AddItem: { bot: Bot };
@@ -116,20 +116,13 @@ const Home = () => {
 		stack = state.isEnterpriseMode ? (
 			<>
 				<Stack.Screen
-					name="Map"
+					name="BottomBar"
 					component={BottomBar}
 					options={{
 						unmountOnBlur: true,
 					}}
 				/>
 				<Stack.Screen name="ItemCatalogue" component={ItemCatalogue} />
-				<Stack.Screen
-					name="Qr"
-					component={BottomBar}
-					options={{
-						unmountOnBlur: true,
-					}}
-				/>
 				<Stack.Screen name="SelectMarker" component={SelectMarkerScreen} />
 				<Stack.Screen name="AddItem" component={AddItem} />
 				<Stack.Screen name="Dashboard" component={DashboardScreen} />
@@ -142,14 +135,7 @@ const Home = () => {
 		) : (
 			<>
 				<Stack.Screen
-					name="Qr"
-					component={BottomBar}
-					options={{
-						unmountOnBlur: true,
-					}}
-				/>
-				<Stack.Screen
-					name="Map"
+					name="BottomBar"
 					component={BottomBar}
 					options={{
 						unmountOnBlur: true,

--- a/src/containers/Map/SelectMarkerScreen.tsx
+++ b/src/containers/Map/SelectMarkerScreen.tsx
@@ -70,7 +70,7 @@ const SelectMarkerScreen = ({ route, navigation }: Props) => {
 				onPress={() => {
 					// @ts-ignore
 					// Navigating inside a nested navigator gives an tsc error.
-					navigation.navigate('Map', {
+					navigation.navigate('BottomBar', {
 						screen: 'Map',
 						params: {
 							botSelected: markers.find((item) => item._id === selected),

--- a/src/containers/Map/mapTypes.ts
+++ b/src/containers/Map/mapTypes.ts
@@ -45,5 +45,5 @@ export interface PropTypes {
 
 export interface MapScreenProps {
 	route: RouteProp<BottomRootStackParamList, 'Map'>;
-	navigation: StackNavigationProp<RootStackParamList, 'Map'>;
+	navigation: StackNavigationProp<RootStackParamList, 'BottomBar'>;
 }

--- a/src/containers/Navbar/BottomBarNavigator.tsx
+++ b/src/containers/Navbar/BottomBarNavigator.tsx
@@ -36,7 +36,7 @@ const BottomBarNavigator = () => {
 
 	return (
 		<BottomTab.Navigator
-			initialRouteName="Map"
+			initialRouteName="Map" // default to Map
 			tabBarOptions={{ inactiveTintColor: '#000' }}
 		>
 			<BottomTab.Screen

--- a/src/containers/Navbar/NavBarScreen.tsx
+++ b/src/containers/Navbar/NavBarScreen.tsx
@@ -45,13 +45,32 @@ export const HeaderButton = ({ navigation, screen }: Props) => {
 	};
 
 	const customConfig: { [screen: string]: ButtonConfig } = {
-		Map: {
-			action: () => navigation.openDrawer(),
-			icon: Menu,
-		},
 		Qr: {
 			action: () => navigation.openDrawer(),
 			icon: Menu,
+		},
+		BottomBar: {
+			// when signed in, BottomBar holds Map and Qr
+			action: () => navigation.openDrawer(),
+			icon: Menu,
+		},
+		SelectMarker: {
+			action: () =>
+				// @ts-ignore
+				// Navigating inside a nested navigator gives an tsc error.
+				navigation.navigate('BottomBar', {
+					screen: 'Map', // go to Map from SelectMarker
+				}),
+			icon: Back,
+		},
+		Dashboard: {
+			action: () =>
+				// @ts-ignore
+				// Navigating inside a nested navigator gives an tsc error.
+				navigation.navigate('BottomBar', {
+					screen: 'Qr', // go to Qr from Dashboard
+				}),
+			icon: Back,
 		},
 	};
 


### PR DESCRIPTION
## Changes

- rename the bottom bar component to `BottomBar` for clarity
- `BottomBar` defaults to the map (bottom bar only appears when a user is logged in)
  - this change was actually made in a previous PR and is now on `main`, just documenting here
- fix how back button interacts with components in the bottom bar
  - `SelectMarker` back button goes back to `Map`
  - `Dashboard` back button goes back to `QR`