### PR TITLE
Send Bot on path on done

### DIFF
--- a/src/containers/Map/MapScreen.tsx
+++ b/src/containers/Map/MapScreen.tsx
@@ -320,6 +320,31 @@ const MapScreen = ({ route, navigation }: MapScreenProps) => {
 							addToRoute(marker);
 						}}
 						isMapPath={!botRoute || botRoute.length === 0 ? false : true}
+						onDone={async () => {
+							if (botRoute) {
+								setLoading(true);
+								let lats: number[] = [];
+								let longs: number[] = [];
+								botRoute.splice(1).map((marker) => {
+									lats.push(marker.location.latitude);
+									longs.push(marker.location.longitude);
+								});
+								await BotService.sendBot(
+									selectedBotForOrder._id,
+									botRoute[0]._id
+								);
+								await BotService.updateQueue(
+									selectedBotForOrder._id,
+									lats,
+									longs
+								);
+								setTimeout(() => {
+									setLoading(false);
+									setShowMapNodes(false);
+									setSelectedBotForOrder(null);
+								}, 1000);
+							}
+						}}
 					/>
 				</View>
 				{selectedMarker && (

--- a/src/containers/Map/MapView.tsx
+++ b/src/containers/Map/MapView.tsx
@@ -56,6 +56,7 @@ const MapComponent = ({
 	onSelect,
 	onNodeSelect,
 	isMapPath,
+	onDone,
 }: PropTypes) => {
 	const mapRef = useRef<MapView>(null);
 	const doneButtonBackgroundColor = isMapPath
@@ -304,7 +305,7 @@ const MapComponent = ({
 						backgroundColor: doneButtonBackgroundColor,
 					}}
 					containerStyle={styles.buttonContainer}
-					onPress={() => {}}
+					onPress={() => onDone()}
 				/>
 			)}
 			{/*<TouchableOpacity style={{...styles.button, ...styles.smallerButton, top: '7.9%', left: 18,}}>

--- a/src/containers/Map/mapTypes.ts
+++ b/src/containers/Map/mapTypes.ts
@@ -31,6 +31,7 @@ export interface PropTypes {
 	refresh(): any;
 	selected?: MarkerData;
 	isMapPath?: boolean;
+	onDone?: any;
 
 	/**
 	 * Function for when a marker is selected

--- a/src/services/BotService.ts
+++ b/src/services/BotService.ts
@@ -64,4 +64,21 @@ async function sendBot(botId: string, nodeId: string) {
 	}
 }
 
-export default { getEventBots, getAllBots, getOneBot, sendBot };
+async function updateQueue(botId: string, lats: number[], longs: number[]) {
+	try {
+		let data: Bot = (
+			await axios.put('/bots/replaceQueue', {
+				botId: botId,
+				latitudeArray: lats,
+				longitudeArray: longs,
+			})
+		).data;
+		console.log(data);
+		return data;
+	} catch (e) {
+		console.log(e);
+		throw e;
+	}
+}
+
+export default { getEventBots, getAllBots, getOneBot, sendBot, updateQueue };


### PR DESCRIPTION
Sends the bot on its path after pressing the done button. As of now, the first marker in path is used for the call toNode and the rest of the markers are placed in a queue that is stored by calling the replaceQueue endpoint. The idea behind this was it only needs to store the path to its current destination and the updateLocation endpoint which will be called to constantly update the location of the bot determines that the bot has reached its next destination, it will check the queue and if there is another marker to go to will find a path to that destination.




